### PR TITLE
8319524: [Lilliput] Only warn when compact headers are explicitly ena…

### DIFF
--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -3097,7 +3097,9 @@ jint Arguments::finalize_vm_init_args(bool patch_mod_javabase) {
 
 #ifdef _LP64
   if (UseCompactObjectHeaders && UseZGC && !ZGenerational) {
-    warning("Single-generational ZGC does not work with compact object headers, disabling UseCompactObjectHeaders");
+    if (FLAG_IS_CMDLINE(UseCompactObjectHeaders)) {
+      warning("Single-generational ZGC does not work with compact object headers, disabling UseCompactObjectHeaders");
+    }
     FLAG_SET_DEFAULT(UseCompactObjectHeaders, false);
   }
   if (UseCompactObjectHeaders && FLAG_IS_CMDLINE(UseCompressedClassPointers) && !UseCompressedClassPointers) {


### PR DESCRIPTION
…bled

Backport-of: 3f73f014097262455cc42a71c32af374b77b6efd